### PR TITLE
Feature/copy multi image

### DIFF
--- a/docs/resources/copy.md
+++ b/docs/resources/copy.md
@@ -52,6 +52,7 @@ resource "skopeo2_copy" "example" {
 ### Optional
 
 - `additional_tags` (List of String) additional tags (supports docker-archive)
+- `copy_all_images` (Boolean) indicates that the caller expects to copy all images from a multiple image manifest, otherwise only one image matching the system arch/platform is copied
 - `insecure` (Boolean) allow access to non-TLS insecure repositories.
 - `keep_image` (Boolean) keep image when Resource gets deleted. This currently needs to be set to `true` when working with GitHub Container registry.
 - `preserve_digests` (Boolean) fail if we cannot preserve the source digests in the destination image.

--- a/examples/skopeo2_example.tf
+++ b/examples/skopeo2_example.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     skopeo2 = {
       source  = "bsquare-corp/skopeo2"
-      version = "0.0.4"
+      version = "0.0.5"
     }
   }
 

--- a/internal/provider/resource_skopeo2_copy.go
+++ b/internal/provider/resource_skopeo2_copy.go
@@ -184,6 +184,13 @@ func resourceSkopeo2Copy() *schema.Resource {
 				Default:     false,
 				Description: "allow access to non-TLS insecure repositories.",
 			},
+			"copy_all_images": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "indicates that the caller expects to copy all images from a multiple image manifest, " +
+					"otherwise only one image matching the system arch/platform is copied",
+			},
 			"docker_digest": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -499,6 +506,7 @@ func newCopyOptions(d *schema.ResourceData, reportWriter *providerlog.ProviderLo
 		RetryOpts:       newRetryOptions(d),
 		AdditionalTags:  additionalTags,
 		PreserveDigests: preserveDigests,
+		All:             d.Get("copy_all_images").(bool),
 	}
 	return opts
 }

--- a/internal/provider/resource_skopeo2_copy_test.go
+++ b/internal/provider/resource_skopeo2_copy_test.go
@@ -101,6 +101,14 @@ func TestAccResourceSkopeo2(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccCopyResourceMultiImage(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("skopeo2_copy.alpine_copy_resource_multi_image_%s",
+						rName),
+						"docker_digest"),
+				),
+			},
+			{
 				Config:      testAccCopyResourceFail(rName),
 				ExpectError: expectErrorRegExpr("requested access to the resource is denied"),
 			},
@@ -168,6 +176,19 @@ func testAccCopyResource(name string) string {
 	  image = "docker://localhost:5000/alpine-copy-resource-%s"
     }
     insecure = true
+}`, name, name)
+}
+
+func testAccCopyResourceMultiImage(name string) string {
+	return fmt.Sprintf(`resource "skopeo2_copy" "alpine_copy_resource_multi_image_%s" {
+    source {
+	  image = "docker://alpine"
+    }
+    destination {
+	  image = "docker://localhost:5000/alpine-copy-resource-multi-image-%s"
+    }
+    insecure = true
+    copy_all_images = true
 }`, name, name)
 }
 

--- a/internal/skopeo/copy.go
+++ b/internal/skopeo/copy.go
@@ -23,11 +23,11 @@ type CopyOptions struct {
 	RetryOpts         *retry.RetryOptions
 	AdditionalTags    []string // For docker-archive: destinations, in addition to the name:tag specified as destination, also add these
 	PreserveDigests   bool     // Fail if we cannot preserve the source digests in the destination image
+	All               bool     // Copy all of the images if the source is a list
 	removeSignatures  bool     // Do not copy signatures from the source image
 	signByFingerprint string   // Sign the image using a GPG key with the specified fingerprint
 	format            string
 	quiet             bool     // Suppress output information when copying images
-	all               bool     // Copy all of the images if the source is a list
 	encryptLayer      []int    // The list of layers to encrypt
 	encryptionKeys    []string // Keys needed to encrypt the image
 	decryptionKeys    []string // Keys needed to decrypt the image
@@ -90,7 +90,7 @@ func Copy(ctx context.Context, sourceImageName, destinationImageName string, opt
 	}
 
 	imageListSelection := copy.CopySystemImage
-	if opts.all {
+	if opts.All {
 		imageListSelection = copy.CopyAllImages
 	}
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary
-	version string = "0.0.4"
+	version string = "0.0.5"
 
 	// goreleaser can also pass the specific commit if you want
 	// commit  string = ""


### PR DESCRIPTION
Added the copy_all_images parameter which is a flag indicating that all images of a multi image manifest is to be copied to the destination instead of just one of the images matching the calling system's architecture and platform.