### PR TITLE
Feature/set docker digest

### DIFF
--- a/docs/resources/copy.md
+++ b/docs/resources/copy.md
@@ -53,6 +53,7 @@ resource "skopeo2_copy" "example" {
 
 - `additional_tags` (List of String) additional tags (supports docker-archive)
 - `copy_all_images` (Boolean) indicates that the caller expects to copy all images from a multiple image manifest, otherwise only one image matching the system arch/platform is copied
+- `docker_digest` (String) digest string for the destination image.
 - `insecure` (Boolean) allow access to non-TLS insecure repositories.
 - `keep_image` (Boolean) keep image when Resource gets deleted. This currently needs to be set to `true` when working with GitHub Container registry.
 - `preserve_digests` (Boolean) fail if we cannot preserve the source digests in the destination image.
@@ -61,7 +62,6 @@ resource "skopeo2_copy" "example" {
 
 ### Read-Only
 
-- `docker_digest` (String) digest string for the destination image.
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--destination"></a>

--- a/internal/provider/resource_skopeo2_copy.go
+++ b/internal/provider/resource_skopeo2_copy.go
@@ -481,16 +481,16 @@ func resourceSkopeo2CopyDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func getStringList(d *schema.ResourceData, key string, def []string) []string {
-	at := d.Get("additional_tags")
+	at := d.Get(key)
 	if at == nil {
 		return def
 	}
 	atl := at.([]interface{})
-	additionalTags := make([]string, 0, len(atl))
+	stringList := make([]string, 0, len(atl))
 	for _, t := range atl {
-		additionalTags = append(additionalTags, t.(string))
+		stringList = append(stringList, t.(string))
 	}
-	return additionalTags
+	return stringList
 }
 
 func newCopyOptions(d *schema.ResourceData, reportWriter *providerlog.ProviderLogWriter) *skopeo.CopyOptions {

--- a/internal/provider/resource_skopeo2_copy.go
+++ b/internal/provider/resource_skopeo2_copy.go
@@ -193,6 +193,7 @@ func resourceSkopeo2Copy() *schema.Resource {
 			},
 			"docker_digest": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Description: "digest string for the destination image.",
 			},
@@ -444,9 +445,6 @@ func resourceSkopeo2CopyRead(ctx context.Context, d *schema.ResourceData, meta a
 }
 
 func resourceSkopeo2CopyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	if !d.HasChanges("additional_tags", "source_image") {
-		return nil
-	}
 	return resourceSkopeo2CopyCreate(ctx, d, meta)
 }
 

--- a/internal/provider/resource_skopeo2_copy_test.go
+++ b/internal/provider/resource_skopeo2_copy_test.go
@@ -149,6 +149,13 @@ func TestAccResourceSkopeo2(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config: testAccCopyResourceWithDigest(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(fmt.Sprintf("skopeo2_copy.alpine_copy_resource_digest_%s", rName),
+						"docker_digest", regexp.MustCompile(`^sha256`)),
+				),
+			},
 			/*
 				{ // TODO Login source can only be executed with an actual AWS account
 					Config: testAccCopyResource_loginSource(rName),
@@ -176,6 +183,26 @@ func testAccCopyResource(name string) string {
 	  image = "docker://127.0.0.1:9016/alpine-copy-resource-%s"
     }
     insecure = true
+}`, name, name)
+}
+
+func testAccCopyResourceWithDigest(name string) string {
+	return fmt.Sprintf(`resource "skopeo2_copy" "alpine_copy_resource_digest_%s" {
+    source {
+	  image = "docker://alpine"
+    }
+    destination {
+	  image = "docker://127.0.0.1:9016/alpine-copy-resource-digest-%s"
+    }
+    insecure = true
+    docker_digest = "testvalue"
+    lifecycle {
+        ignore_changes = [
+          # For unit test only, because the teat fails due to the test value of docker_digest not matching the actual
+          # destination digest
+          docker_digest,
+      ]
+    }
 }`, name, name)
 }
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary
-	version string = "0.0.6"
+	version string = "0.0.7"
 
 	// goreleaser can also pass the specific commit if you want
 	// commit  string = ""


### PR DESCRIPTION
This change allows you to set the docker_digest value to the expected digest which means a copy will be triggered if the destination image does not have the expected digest for any reason.