### PR TITLE
Remove usage of syscall which is incompatible with windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/containers/storage v1.48.0
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/go-cmd/cmd v1.4.2
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/go-cmd/cmd v1.4.2 h1:pnX38iIJHh4huzBSqfkAZkfXrVwM/5EccAJmrVqMnbg=
+github.com/go-cmd/cmd v1.4.2/go.mod h1:u3hxg/ry+D5kwh8WvUkHLAMe2zQCaXd00t35WfQaOFk=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/go-billy/v5 v5.4.1 h1:Uwp5tDRkPr+l/TnbHOQzp+tmJfLceOlbVucgpTz8ix4=
 github.com/go-git/go-git/v5 v5.6.1 h1:q4ZRqQl4pR/ZJHc1L5CFjGA1a10u76aV1iC+nh+bHsk=

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	// Version these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary
-	version string = "0.0.8"
+	version string = "0.0.9"
 
 	// goreleaser can also pass the specific commit if you want
 	// commit  string = ""

--- a/pkg/skopeo/options.go
+++ b/pkg/skopeo/options.go
@@ -6,7 +6,7 @@ import (
 	"github.com/containers/image/v5/types"
 )
 
-var defaultUserAgent = "terraform-provider-skopeo2/0.0.8"
+var defaultUserAgent = "terraform-provider-skopeo2/0.0.9"
 
 type GlobalOptions struct {
 	Debug              bool          // Enable debug output


### PR DESCRIPTION
syscall usage causes the release build for v0.0.8 to fail when building the windows binary.